### PR TITLE
typo

### DIFF
--- a/site.htm
+++ b/site.htm
@@ -9,5 +9,5 @@
 <p style="font-family: Arial">to join, you can request to us <a style="font-family: Arial" href="https://scratch.mit.edu/studios/35370452/comments">here.</a></p>
 <h1  style="font-family: Arial">Links</h1>
 <a style="font-family: Arial" href="https://scratch.mit.edu/discuss/topic/768740/">Official Forums</a>
-<a style="font-family: Arial" href="https://github.com/Scratch-Computng-Alliance/SCA-OSSLs/blob/main/open-source/open-source%20OSSL%201.0">SCA-OSSL</a>
+<a style="font-family: Arial" href="https://github.com/Scratch-Computng-Alliance/SCA-OSSLs/blob/main/open-source/open-source%20OSSL%201.0">SCA-OSSL(S)</a>
 <p style="font-size: 10px">(c) 2024 SCA all rights reserved.</p>


### PR DESCRIPTION
fixed a typo:
link: SCA-OSSL to SCA-OSSL(S)